### PR TITLE
Launch forms via odkcollect:// links, with entity preselection

### DIFF
--- a/.github/workflows/custom_release.yml
+++ b/.github/workflows/custom_release.yml
@@ -1,0 +1,44 @@
+# Workflow to deploy custom builds on ODK Collect
+
+name: 🔧 Build and Release
+
+on:
+  release:
+    types: [published]
+  # Allow manual trigger (workflow_dispatch)
+  workflow_dispatch:
+
+jobs:
+  build_upload_apk:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    container:
+        image: docker.io/cimg/android:2023.10.1
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Add Robolectric Deps
+        run: ./download-robolectric-deps.sh
+
+      - name: Compile Code
+        run: ./gradlew assembleDebug
+
+      - name: Install Github CLI
+        run: |
+          sudo apt update
+          sudo apt install --no-install-recommends -y gh
+
+      - name: Build & Upload APK
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew assembleSelfSignedRelease
+
+          apk_path=$(find ./collect_app/build/outputs/apk/selfSignedRelease -name '*.apk' -type f)
+          echo "Generated APK file: ${apk_path}"
+
+          gh release upload ${{ github.event.release.tag_name }} "${apk_path}"

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -121,7 +121,15 @@ the specific language governing permissions and limitations under the License.
         <activity
             android:name=".activities.FormFillingActivity"
             android:theme="@style/Theme.Collect.FormEntry"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <data android:scheme="odkcollect" android:host="form" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+            </intent-filter>
+        </activity>
         <activity
             android:name="org.odk.collect.draw.DrawActivity"
             android:screenOrientation="landscape" />

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -97,7 +97,20 @@ the specific language governing permissions and limitations under the License.
         </provider>
 
         <activity
-            android:name=".activities.FirstLaunchActivity">
+            android:name=".activities.FirstLaunchActivity"
+            android:exported="true">
+
+            <!--
+             This intent-filter enables the launching of FirstLaunchActivity
+             via in-browser links in the format
+             "odkcollect://project/configuration?data=<settings-data>"
+           -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <data android:scheme="odkcollect" android:host="project" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+            </intent-filter>
         </activity>
 
         <activity

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -123,6 +123,11 @@ the specific language governing permissions and limitations under the License.
             android:theme="@style/Theme.Collect.FormEntry"
             android:windowSoftInputMode="adjustResize"
             android:exported="true">
+            <!--
+              This intent-filter enables the launching of FormFillingActivity
+              on a specific form via in-browser links in the format
+              "odkcollect://form/<form_id>" (see FormLoaderTask for details).
+            -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <data android:scheme="odkcollect" android:host="form" />

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -104,6 +104,7 @@ the specific language governing permissions and limitations under the License.
              This intent-filter enables the launching of FirstLaunchActivity
              via in-browser links in the format
              "odkcollect://project/configuration?data=<settings-data>"
+             to set up the project.
            -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
@@ -134,20 +135,7 @@ the specific language governing permissions and limitations under the License.
         <activity
             android:name=".activities.FormFillingActivity"
             android:theme="@style/Theme.Collect.FormEntry"
-            android:windowSoftInputMode="adjustResize"
-            android:exported="true">
-            <!--
-              This intent-filter enables the launching of FormFillingActivity
-              on a specific form via in-browser links in the format
-              "odkcollect://form/<form_id>" (see FormLoaderTask for details).
-            -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-                <data android:scheme="odkcollect" android:host="form" />
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-            </intent-filter>
-        </activity>
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name="org.odk.collect.draw.DrawActivity"
             android:screenOrientation="landscape" />
@@ -349,6 +337,19 @@ the specific language governing permissions and limitations under the License.
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="vnd.android.cursor.item/vnd.odk.form" />
                 <data android:mimeType="vnd.android.cursor.item/vnd.odk.instance" />
+            </intent-filter>
+
+            <!--
+              This intent-filter enables the launching of FormUriActivity
+              via in-browser links in the format
+              "odkcollect://form/<form_id>" (see FormUriActivity for details).
+              It leads to open the form with the given form id with pre filled forms
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <data android:scheme="odkcollect" android:host="form" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
             </intent-filter>
         </activity>
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FirstLaunchActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FirstLaunchActivity.kt
@@ -14,8 +14,11 @@ import org.odk.collect.android.databinding.FirstLaunchLayoutBinding
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.projects.ManualProjectCreatorDialog
+import org.odk.collect.android.projects.ProjectCreator
 import org.odk.collect.android.projects.ProjectsDataService
 import org.odk.collect.android.projects.QrCodeProjectCreatorDialog
+import org.odk.collect.android.projects.SettingsConnectionMatcher
+import org.odk.collect.android.utilities.ProjectSetupHelper
 import org.odk.collect.android.version.VersionInformation
 import org.odk.collect.androidshared.system.ContextUtils.getThemeAttributeValue
 import org.odk.collect.androidshared.ui.DialogFragmentUtils
@@ -25,6 +28,7 @@ import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.strings.localization.LocalizedActivity
+import timber.log.Timber
 import javax.inject.Inject
 
 class FirstLaunchActivity : LocalizedActivity() {
@@ -40,6 +44,9 @@ class FirstLaunchActivity : LocalizedActivity() {
 
     @Inject
     lateinit var settingsProvider: SettingsProvider
+
+    @Inject
+    lateinit var projectCreator: ProjectCreator
 
     @Inject
     lateinit var scheduler: Scheduler
@@ -102,7 +109,12 @@ class FirstLaunchActivity : LocalizedActivity() {
                 text = SpannableStringBuilder()
                     .append(getString(org.odk.collect.strings.R.string.dont_have_project))
                     .append(" ")
-                    .color(getThemeAttributeValue(context, com.google.android.material.R.attr.colorAccent)) {
+                    .color(
+                        getThemeAttributeValue(
+                            context,
+                            com.google.android.material.R.attr.colorAccent
+                        )
+                    ) {
                         append(getString(org.odk.collect.strings.R.string.try_demo))
                     }
 
@@ -110,6 +122,41 @@ class FirstLaunchActivity : LocalizedActivity() {
                     viewModel.tryDemo()
                 }
             }
+
+            // When the FirstLaunchActivity is started via a browsable link in
+            // the format "odkcollect://project/configuration?data=<settings-data>",
+            // setup project automatically if data is valid
+            initiateProjectSetUp()
+        }
+    }
+
+    /**
+     * Method to initiate project setup from a URI.
+     * When the FirstLaunchActivity is started via a browsable link in
+     * the format "odkcollect://project/configuration?data=<settings-data>",
+     * setup project automatically if data is valid
+     */
+    private fun initiateProjectSetUp() {
+        try {
+            val uri = intent.data
+
+            if (uri?.scheme != "odkcollect" || uri.host != "project") return
+
+            val segment = uri.pathSegments.firstOrNull()
+
+            if (segment != "configuration") return
+
+            val helper = ProjectSetupHelper(
+                this,
+                SettingsConnectionMatcher(projectsRepository, settingsProvider),
+                projectCreator,
+                projectsDataService
+            )
+
+            helper.initiateSetup(uri)
+
+        } catch (e: Exception) {
+            Timber.e(e)
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -74,6 +74,11 @@ object AnalyticsEvents {
     const val QR_CREATE_PROJECT = "ProjectCreateQR"
 
     /**
+     * Tracks how often projects are created using deeplink.
+     */
+    const val DEEPLINK_CREATE_PROJECT = "ProjectCreateDeeplink"
+
+    /**
      * Tracks how often projects are created by manually entering details.
      */
     const val MANUAL_CREATE_PROJECT = "ProjectCreateManual"

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -265,7 +265,11 @@ private class FormUriViewModel(
             },
             foreground = {
                 _formUriValidationResult.value = if (it == null) {
-                    Valid(_uri!!)
+                    _uri?.let { uri ->
+                        Valid(uri)
+                    } ?: run {
+                        Invalid("Invalid Uri")
+                    }
                 } else {
                     Invalid(it)
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -70,7 +70,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 
 import timber.log.Timber;
@@ -182,17 +181,6 @@ public class FormLoaderTask extends SchedulerAsyncTaskMimic<Void, String, FormLo
              * explicitly saved instance is edited via edit-saved-form.
              */
             instancePath = loadSavePoint();
-        } else if (Objects.equals(uri.getScheme(), "odkcollect") && Objects.equals(uri.getHost(), "form")) {
-            // When the FormFillingActivity is started via a browsable link in
-            // the format "odkcollect://form/<form_id>", we want to launch and
-            // load the form with the specified Form ID.  (<form_id> is the
-            // form ID in the form definition, not the local form ID.)
-            form = new FormsRepositoryProvider(Collect.getInstance()).get().get(ContentUriHelper.getIdFromUri(uri));
-            if (form == null) {
-                Timber.e(new Error("form is null"));
-                errorMsg = "This form no longer exists, please email support@getodk.org with a description of what you were doing when this happened.";
-                return null;
-            }
         }
 
         if (form.getFormFilePath() == null) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -182,7 +182,10 @@ public class FormLoaderTask extends SchedulerAsyncTaskMimic<Void, String, FormLo
              */
             instancePath = loadSavePoint();
         } else if (uri.getScheme().equals("odkcollect") && uri.getHost().equals("form")) {
-            // Launch a form from a browsable web link in the format: odkcollect://form/<form_id>
+            // When the FormFillingActivity is started via a browsable link in
+            // the format "odkcollect://form/<form_id>", we want to launch and
+            // load the form with the specified Form ID.  (<form_id> is the
+            // form ID in the form definition, not the local form ID.)
             String formId = uri.getPathSegments().get(0);
             List<Form> forms = new FormsRepositoryProvider(Collect.getInstance()).get().getAllByFormId(formId);
             if (forms.size() == 0) {
@@ -283,21 +286,32 @@ public class FormLoaderTask extends SchedulerAsyncTaskMimic<Void, String, FormLo
             }
         }
 
+        // Preselect the entity specified in a URI query parameter, if any.
         preselectEntity(fc, uri);
 
         data = new FECWrapper(fc, usedSavepoint);
         return data;
     }
 
+    /**
+     * Prefills top-level select-one fields in the form, according to query
+     * parameters given in the intent URI.
+     */
     private void preselectEntity(FormController fc, Uri uri) {
+        // We need to save the current form index in order to restore it
+        // after iterating through the form.
         FormIndex saved = fc.getFormIndex();
         try {
+            // We assume that entity selection happens in a top-level question,
+            // so no need to step into groups, i.e. stepToNextEvent(false).
             for (int event = fc.jumpToIndex(FormIndex.createBeginningOfFormIndex());
                  event != FormEntryController.EVENT_END_OF_FORM;
                 event = fc.stepToNextEvent(false)) {
                 FormIndex index = fc.getFormIndex();
                 TreeReference ref = fc.getFormDef().getChildInstanceRef(index);
                 if (ref != null) {
+                    // If there's a query parameter matching this question,
+                    // we prefill the question using the parameter value.
                     String value = uri.getQueryParameter(ref.getNameLast());
                     if (value != null) {
                         try {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriHelper.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriHelper.kt
@@ -24,32 +24,33 @@ object ContentUriHelper {
 
     @JvmStatic
     fun getIdFromUri(contentUri: Uri): Long {
-        val lastSegmentIndex = contentUri.pathSegments.size - 1
-        val idSegment = contentUri.pathSegments[lastSegmentIndex]
-
-        var idSegmentNew = idSegment
-        /// get form dBId from form's jrFormId
-        if(idSegmentNew.contains("-")){
+        val idSegment = contentUri.pathSegments.last()
+        if (idSegment.toLongOrNull() == null) {
             val forms: List<Form> =
                 FormsRepositoryProvider(Collect.getInstance()).get().getAllByFormId(idSegment)
-            idSegmentNew = "${forms.first().dbId}"
+
+            return forms.firstOrNull()?.dbId ?: -1
         }
 
-        return idSegmentNew.toLong()
+        return idSegment.toLong()
     }
 
     @JvmStatic
     fun getFileExtensionFromUri(fileUri: Uri): String? {
         val mimeType = Collect.getInstance().contentResolver.getType(fileUri)
-        var extension = if (fileUri.scheme != null && fileUri.scheme == ContentResolver.SCHEME_CONTENT) MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) else MimeTypeMap.getFileExtensionFromUrl(fileUri.toString())
-        if (extension == null || extension.isEmpty()) {
-            Collect.getInstance().contentResolver.query(fileUri, null, null, null, null).use { cursor ->
-                var name: String? = null
-                if (cursor != null && cursor.moveToFirst()) {
-                    name = cursor.getString(cursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME))
+        var extension =
+            if (fileUri.scheme != null && fileUri.scheme == ContentResolver.SCHEME_CONTENT) MimeTypeMap.getSingleton()
+                .getExtensionFromMimeType(mimeType) else MimeTypeMap.getFileExtensionFromUrl(fileUri.toString())
+        if (extension.isNullOrEmpty()) {
+            Collect.getInstance().contentResolver.query(fileUri, null, null, null, null)
+                .use { cursor ->
+                    var name: String? = null
+                    if (cursor != null && cursor.moveToFirst()) {
+                        name =
+                            cursor.getString(cursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME))
+                    }
+                    extension = name?.substring(name.lastIndexOf('.') + 1) ?: ""
                 }
-                extension = name?.substring(name.lastIndexOf('.') + 1) ?: ""
-            }
         }
 
         if (extension!!.isEmpty() && mimeType != null && mimeType.contains("/")) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriHelper.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriHelper.kt
@@ -18,6 +18,7 @@ import android.net.Uri
 import android.provider.MediaStore
 import android.webkit.MimeTypeMap
 import org.odk.collect.android.application.Collect
+import org.odk.collect.forms.Form
 
 object ContentUriHelper {
 
@@ -25,7 +26,16 @@ object ContentUriHelper {
     fun getIdFromUri(contentUri: Uri): Long {
         val lastSegmentIndex = contentUri.pathSegments.size - 1
         val idSegment = contentUri.pathSegments[lastSegmentIndex]
-        return idSegment.toLong()
+
+        var idSegmentNew = idSegment
+        /// get form dBId from form's jrFormId
+        if(idSegmentNew.contains("-")){
+            val forms: List<Form> =
+                FormsRepositoryProvider(Collect.getInstance()).get().getAllByFormId(idSegment)
+            idSegmentNew = "${forms.first().dbId}"
+        }
+
+        return idSegmentNew.toLong()
     }
 
     @JvmStatic

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriHelper.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriHelper.kt
@@ -19,6 +19,7 @@ import android.provider.MediaStore
 import android.webkit.MimeTypeMap
 import org.odk.collect.android.application.Collect
 import org.odk.collect.forms.Form
+import timber.log.Timber
 
 object ContentUriHelper {
 
@@ -26,10 +27,15 @@ object ContentUriHelper {
     fun getIdFromUri(contentUri: Uri): Long {
         val idSegment = contentUri.pathSegments.last()
         if (idSegment.toLongOrNull() == null) {
-            val forms: List<Form> =
-                FormsRepositoryProvider(Collect.getInstance()).get().getAllByFormId(idSegment)
+            try {
+                val forms: List<Form> =
+                    FormsRepositoryProvider(Collect.getInstance()).get().getAllByFormId(idSegment)
+                return forms.firstOrNull()?.dbId ?: -1
+            } catch (e: Exception) {
+                Timber.e("Error getting form id: %s", e.message)
+            }
 
-            return forms.firstOrNull()?.dbId ?: -1
+            return -1
         }
 
         return idSegment.toLong()

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ProjectSetupHelper.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ProjectSetupHelper.kt
@@ -1,0 +1,152 @@
+package org.odk.collect.android.utilities
+
+import android.net.Uri
+import androidx.appcompat.app.AppCompatActivity
+import org.odk.collect.analytics.Analytics
+import org.odk.collect.android.activities.ActivityUtils
+import org.odk.collect.android.analytics.AnalyticsEvents
+import org.odk.collect.android.mainmenu.MainMenuActivity
+import org.odk.collect.android.projects.DuplicateProjectConfirmationDialog
+import org.odk.collect.android.projects.ProjectCreator
+import org.odk.collect.android.projects.ProjectsDataService
+import org.odk.collect.android.projects.SettingsConnectionMatcher
+import org.odk.collect.androidshared.ui.ToastUtils
+import org.odk.collect.androidshared.ui.ToastUtils.showShortToast
+import org.odk.collect.androidshared.utils.CompressionUtils
+import org.odk.collect.settings.importing.SettingsImportingResult
+import timber.log.Timber
+
+/**
+ * Helper class to set up a project from a deeplink URI.
+ * It takes following parameters:
+ * - activity: It is the AppCompatActivity instance. It will be used to start the MainMenuActivity.
+ * - settingsConnectionMatcher: It is the SettingsConnectionMatcher instance. It is used to check for duplicate project
+ * - projectCreator: It is the ProjectCreator instance. It is used to create a new project.
+ * - projectsDataService: It is the ProjectsDataService instance. It is used to check if the project is already a current project.
+ */
+class ProjectSetupHelper(
+    private val activity: AppCompatActivity,
+    private val settingsConnectionMatcher: SettingsConnectionMatcher,
+    private val projectCreator: ProjectCreator,
+    private val projectsDataService: ProjectsDataService,
+) :
+    DuplicateProjectConfirmationDialog.DuplicateProjectConfirmationListener {
+
+    /**
+     * Method to set up a project from a deeplink URI.
+     */
+    fun initiateSetup(uri: Uri) {
+        // Get the project settings from the URI
+        // Here we are replacing the "space" with "+" because the
+        // "+" char is replaced by "space" while coming through the deep link
+        val projectSettingJsonStr = uri.getQueryParameter("data")?.replace(" ", "+")
+
+        // If the URI doesn't contain a settings parameter, return
+        if (projectSettingJsonStr == null) {
+            showShortToast(
+                activity.applicationContext,
+                "Uri doesn't contain a settings data"
+            )
+            return
+        }
+
+        // Decompress the project settings configuration string if valid
+        // It will try to decompress the settings data from the query parameter
+        // If the settings data is invalid, show a toast and return
+        // If the settings data is valid, create the project
+        val settingsJson = try {
+            CompressionUtils.decompress(projectSettingJsonStr)
+        } catch (e: Exception) {
+            showShortToast(
+                activity.applicationContext,
+                "Invalid project configuration data"
+            )
+            null
+        } ?: return
+
+        // Create the project
+        createProjectOrError(settingsJson)
+    }
+
+    /**
+     * Method to check the duplicate project and create a new project if needed.
+     */
+    private fun createProjectOrError(settingsJson: String) {
+        settingsConnectionMatcher.getProjectWithMatchingConnection(settingsJson)?.let { uuid ->
+            // Switch to project if it is not already a current project
+            try {
+                // Checking if project is already a current project
+                val alreadyCurrentProject = projectsDataService.getCurrentProject().uuid == uuid
+
+                // If not current project, switch to it
+                if (!alreadyCurrentProject) switchToProject(uuid)
+
+                // Else just navigate to the project
+                else navigateToProject()
+
+            } catch (e: Exception) {
+                Timber.e("Error occurred while getting current project: %s", e.message)
+            }
+
+        } ?: run {
+            createProject(settingsJson)
+        }
+    }
+
+    /**
+     * Method to create a new project.
+     */
+    override fun createProject(settingsJson: String) {
+        when (projectCreator.createNewProject(settingsJson)) {
+            SettingsImportingResult.SUCCESS -> {
+                Analytics.log(AnalyticsEvents.DEEPLINK_CREATE_PROJECT)
+
+                ActivityUtils.startActivityAndCloseAllOthers(
+                    activity,
+                    MainMenuActivity::class.java
+                )
+                ToastUtils.showLongToast(
+                    activity.applicationContext,
+                    activity.getString(
+                        org.odk.collect.strings.R.string.switched_project,
+                        projectsDataService.getCurrentProject().name
+                    )
+                )
+            }
+
+            SettingsImportingResult.INVALID_SETTINGS -> ToastUtils.showLongToast(
+                activity.applicationContext,
+                "Invalid project configuration data"
+            )
+
+            SettingsImportingResult.GD_PROJECT -> ToastUtils.showLongToast(
+                activity.applicationContext,
+                activity.getString(
+                    org.odk.collect.strings.R.string.settings_with_gd_protocol
+                )
+            )
+        }
+    }
+
+    /**
+     * Method to switch to an existing project.
+     */
+    override fun switchToProject(uuid: String) {
+        projectsDataService.setCurrentProject(uuid)
+        ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
+        ToastUtils.showLongToast(
+            activity.applicationContext,
+            activity.getString(
+                org.odk.collect.strings.R.string.switched_project,
+                projectsDataService.getCurrentProject().name
+            )
+        )
+    }
+
+    /**
+     * Method to handle navigation to the project.
+     */
+    private fun navigateToProject() {
+        ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/version/VersionInformation.java
+++ b/collect_app/src/main/java/org/odk/collect/android/version/VersionInformation.java
@@ -45,9 +45,18 @@ public class VersionInformation {
         String[] components = getVersionDescriptionComponents();
 
         if (isBeta() && components.length > 3) {
-            return Integer.parseInt(components[2]);
+            try {
+                return Integer.parseInt(components[2]);
+            }catch (NumberFormatException numberFormatException){
+                return null;
+            }
         } else if (!isBeta() && components.length > 2) {
-            return Integer.parseInt(components[1]);
+            try {
+                return Integer.parseInt(components[1]);
+            }catch (NumberFormatException numberFormatException){
+                return null;
+            }
+
         } else {
             return null;
         }

--- a/download-robolectric-deps.sh
+++ b/download-robolectric-deps.sh
@@ -11,16 +11,17 @@ wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/13-robolectric-9030017-i4/android-all-instrumented-13-robolectric-9030017-i4.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/14-robolectric-10818077-i4/android-all-instrumented-14-robolectric-10818077-i4.jar -P robolectric-deps
 
-mkdir -p collect_app/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p audiorecorder/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p projects/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p location/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p androidshared/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p geo/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p permissions/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p settings/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p maps/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p errors/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p selfie-camera/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p qr-code/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p draw/src/test/resources && cp robolectric-deps.properties "$_"
+dest_dir="src/test/resources"
+mkdir -p collect_app/$dest_dir && cp robolectric-deps.properties collect_app/$dest_dir
+mkdir -p audiorecorder/$dest_dir && cp robolectric-deps.properties audiorecorder/$dest_dir
+mkdir -p projects/$dest_dir && cp robolectric-deps.properties projects/$dest_dir
+mkdir -p location/$dest_dir && cp robolectric-deps.properties location/$dest_dir
+mkdir -p androidshared/$dest_dir && cp robolectric-deps.properties androidshared/$dest_dir
+mkdir -p geo/$dest_dir && cp robolectric-deps.properties geo/$dest_dir
+mkdir -p permissions/$dest_dir && cp robolectric-deps.properties permissions/$dest_dir
+mkdir -p settings/$dest_dir && cp robolectric-deps.properties settings/$dest_dir
+mkdir -p maps/$dest_dir && cp robolectric-deps.properties maps/$dest_dir
+mkdir -p errors/$dest_dir && cp robolectric-deps.properties errors/$dest_dir
+mkdir -p selfie-camera/$dest_dir && cp robolectric-deps.properties selfie-camera/$dest_dir
+mkdir -p qr-code/$dest_dir && cp robolectric-deps.properties qr-code/$dest_dir
+mkdir -p draw/$dest_dir && cp robolectric-deps.properties draw/$dest_dir


### PR DESCRIPTION
This proof of concept enables the use of a browsable link to launch the FormFillingActivity on a specific form.  A query parameter in the link can also preselect an entity in the form.

The implementation consists of three parts:

1. Add an `<intent-filter>` to the manifest entry for FormFillingActivity, which catches URLs that begin with `odkcollect://form/`

2. Add a branch in the FormLoaderTask that handles an incoming intent with this kind of URL by looking up a specific form by its Form ID (e.g. "trees_follow_up") rather than its internal id (e.g. "forms/2").

3. Add a method `preselectEntity` that pre-answers a question in the form, according to a query parameter in the URL.  The parameter name should match the name of the question, and the parameter value should be the UUID of the entity.

With these changes, a webpage with a link such as the following will launch ODK Collect into the form filling flow, for a specific form, with an entity preselected:

```
Launch a form:
<a href="odkcollect://form/trees_follow_up?tree=71297c7d-6a22-4354-b08a-3fbee155d74e">
  trees_follow_up
</a>
```

For testing, the above HTML is available here so you can load it on a phone browser: https://zestyping.github.io/odkform